### PR TITLE
fix: CS-656 Missing file persistence for tail position for filelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@ To quickly test how the app works with a vm run the following script to install 
 
 ### Linux Install
 ```
-# Important - file_storage extension needs directory created
-mkdir -p /var/lib/otelcol/file_storage/receiver
-
 curl https://raw.githubusercontent.com/observeinc/host-quickstart-configuration/main/opentelemetry/linux/observe_otel_install.sh | bash -s -- --observe_collection_endpoint "${OBSERVE_COLLECTION_ENDPOINT}" --observe_token "${OBSERVE_TOKEN}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ To quickly test how the app works with a vm run the following script to install 
 
 ### Linux Install
 ```
+# Important - file_storage extension needs directory created
+mkdir -p /var/lib/otelcol/file_storage/receiver
+
 curl https://raw.githubusercontent.com/observeinc/host-quickstart-configuration/main/opentelemetry/linux/observe_otel_install.sh | bash -s -- --observe_collection_endpoint "${OBSERVE_COLLECTION_ENDPOINT}" --observe_token "${OBSERVE_TOKEN}"
 ```
 

--- a/opentelemetry/linux/observe_otel_install.sh
+++ b/opentelemetry/linux/observe_otel_install.sh
@@ -68,6 +68,8 @@ create_config(){
     sudo tee "$config_file" > /dev/null << EOT
 extensions:
   health_check:
+  file_storage:
+    directory: /var/lib/otelcol/file_storage/receiver
 connectors:
   count:
 receivers:
@@ -122,6 +124,7 @@ receivers:
   filelog:
     include: [/var/log/**/*.log, /var/log/syslog]
     include_file_path: true
+    storage: file_storage
     retry_on_failure:
       enabled: true
     max_log_size: 4MiB
@@ -201,7 +204,7 @@ service:
       processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
       exporters: [logging, otlphttp, count]
 
-  extensions: [health_check]
+  extensions: [health_check, file_storage]
 
 EOT
 

--- a/opentelemetry/linux/observe_otel_install.sh
+++ b/opentelemetry/linux/observe_otel_install.sh
@@ -64,6 +64,9 @@ install_apt(){
 
 # create a configuration file with vars
 create_config(){
+    # Important - file_storage extension needs directory created
+    mkdir -p /var/lib/otelcol/file_storage/receiver
+
     sudo mv "$config_file" "$config_file.ORIG"
     sudo tee "$config_file" > /dev/null << EOT
 extensions:


### PR DESCRIPTION
Missing the file_storage extension for file log receiver

Tested on customer environment today when i realized it was missing.

Making immediate fix on Linux and will followup on fix for Mac and Windows.